### PR TITLE
fix: actually use once for emitter

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ class ModAPI {
   }
 
   once(event, listener) {
-    emitter.on(event, listener)
+    emitter.once(event, listener)
   }
 
   off(event, listener) {


### PR DESCRIPTION
This should actually use the once method as expected